### PR TITLE
add propagate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+on:
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        include:
+          # version number must be string, otherwise 3.10 becomes 3.1
+          - os: windows-latest
+            python-version: "3.10"
+          - os: macos-latest
+            python-version: "3.6"
+          - os: ubuntu-latest
+            python-version: "pypy-3.7"
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - run: python -m pip install --upgrade pip
+    - run: python -m pip install -e '.[test]'
+    - run: python -m pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+name: test
+
 on:
   pull_request:
     paths-ignore:

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ venv
 notebook/.ipynb_checkpoints
 src/jacobi/_version.py
 doc/index.rst
+.vscode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
     "setuptools>=42",
     "setuptools_scm[toml]>=3.4",
-    "wheel"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/src/jacobi/__init__.py
+++ b/src/jacobi/__init__.py
@@ -3,5 +3,5 @@
 Fast numerical derivatives for real analytic functions with arbitrary round-off error.
 """
 
-from .core import jacobi  # noqa
+from .core import jacobi, propagate  # noqa
 from ._version import version as __version__  # noqa

--- a/src/jacobi/core.py
+++ b/src/jacobi/core.py
@@ -1,6 +1,16 @@
 import numpy as np
 import typing as _tp
 
+_T = _tp.TypeVar("_T")
+
+
+class _Indexable(_tp.Iterable, _tp.Sized, _tp.Generic[_T]):
+    """Indexable type for mypy."""
+
+    def __getitem__(self, idx: int) -> _T:
+        """Get item at index idx."""
+        ...  # pragma: no cover
+
 
 def _steps(p, step, maxiter):
     h0, factor = step
@@ -224,3 +234,61 @@ def jacobi(
         err = np.squeeze(err)
 
     return jac, err
+
+
+def propagate(
+    fn: _tp.Callable,
+    x: _tp.Union[float, _Indexable[float]],
+    cov: _tp.Union[float, _Indexable[float], _Indexable[_Indexable[float]]],
+    **kwargs,
+) -> _tp.Tuple[np.ndarray, np.ndarray]:
+    """
+    Numerically propagates the covariance into a new space.
+
+    The function does error propagation. It computes C' = J C J^T, where C is the
+    covariance matrix of the input, C' the matrix of the output, and J is the Jacobi
+    matrix of first derivatives of the mapping function fn. The Jacobi matrix is
+    computed numerically.
+
+    Parameters
+    ----------
+    fn: callable
+        Vectorized function that computes y = fn(x).
+    x: float or array-like with shape (N,)
+        Input vector.
+    cov: float or array-like with shape (N,) or shape(N, N)
+        Covariance matrix of input vector. If the array is one-dimensional, it is
+        interpreted as the diagonal of a covariance matrix with zero off-diagonal
+        elements.
+    **kwargs:
+        Extra arguments are passed to :func:`jacobi`.
+
+    Returns
+    -------
+    y, ycov
+        y is the result of fn(x)
+        ycov is the propagated covariance matrix.
+    """
+    x = np.array(x)
+    y = fn(x)
+    jac = jacobi(fn, x, **kwargs)[0]
+
+    x_nd = np.ndim(x)
+    y_nd = np.ndim(y)
+    x_len = len(x) if x_nd == 1 else 1
+    y_len = len(y) if y_nd == 1 else 1
+
+    jac_nd = np.ndim(jac)
+    if jac_nd == 0:
+        jac = np.atleast_2d(jac)
+    elif jac_nd == 1:
+        jac = jac.reshape((y_len, x_len))
+
+    xcov = np.atleast_1d(cov)
+    xcov_nd = np.ndim(xcov)
+
+    if xcov.shape[0] != x_len:
+        raise ValueError("x and cov have incompatible shapes")
+
+    ycov = np.einsum("il,kl,l" if xcov_nd == 1 else "ij,kl,jl", jac, jac, xcov)
+    return y, ycov

--- a/src/jacobi/core.py
+++ b/src/jacobi/core.py
@@ -243,17 +243,17 @@ def propagate(
     **kwargs,
 ) -> _tp.Tuple[np.ndarray, np.ndarray]:
     """
-    Numerically propagates the covariance into a new space.
+    Numerically propagates the covariance of function inputs to function outputs.
 
-    The function does error propagation. It computes C' = J C J^T, where C is the
-    covariance matrix of the input, C' the matrix of the output, and J is the Jacobi
-    matrix of first derivatives of the mapping function fn. The Jacobi matrix is
-    computed numerically.
+    The function computes C' = J C J^T, where C is the covariance matrix of the input,
+    C' the matrix of the output, and J is the Jacobi matrix of first derivatives of the
+    mapping function fn. The Jacobi matrix is computed numerically.
 
     Parameters
     ----------
     fn: callable
-        Vectorized function that computes y = fn(x).
+        Function that computes y = fn(x). x and y are each allowed to be scalars or
+        one-dimensional arrays.
     x: float or array-like with shape (N,)
         Input vector.
     cov: float or array-like with shape (N,) or shape(N, N)

--- a/test/test_jacobi.py
+++ b/test/test_jacobi.py
@@ -46,7 +46,7 @@ def fd6(r):
 
 
 def f7(x):
-    return np.ones(3) * x ** 2
+    return np.ones(3) * x**2
 
 
 @pytest.mark.parametrize(

--- a/test/test_jacobi.py
+++ b/test/test_jacobi.py
@@ -45,6 +45,10 @@ def fd6(r):
     return r
 
 
+def f7(x):
+    return np.ones(3) * x ** 2
+
+
 @pytest.mark.parametrize(
     "fn",
     [
@@ -63,6 +67,14 @@ def test_jacobi(fn):
     f, fd = fn
     y, ye = jacobi(f, x)
     assert_allclose(y, fd(x))
+    assert_allclose(ye, np.zeros_like(y), atol=1e-10)
+
+
+def test_jacobi_0d():
+    x = 2
+    y, ye = jacobi(f7, x)
+    assert np.ndim(y) == 1
+    assert_allclose(y, f7(x))
     assert_allclose(ye, np.zeros_like(y), atol=1e-10)
 
 

--- a/test/test_propagate.py
+++ b/test/test_propagate.py
@@ -1,0 +1,60 @@
+import numpy as np
+from numpy.testing import assert_allclose
+from jacobi import propagate
+import pytest
+
+
+def test_00():
+    def fn(x):
+        return x ** 2 + 5
+
+    x = 2
+    xcov = 3
+    y, ycov = propagate(fn, x, xcov)
+    assert_allclose(y, fn(x))
+    assert_allclose(ycov, (2 * x) ** 2 * xcov)
+
+
+def test_01():
+    def fn(x):
+        return np.ones(2) * x ** 2
+
+    x = 2
+    xcov = 3
+    y, ycov = propagate(fn, x, xcov)
+    assert_allclose(y, fn(x))
+    jac = (2 * x) * np.ones((2, 1))
+    xcov2 = np.atleast_2d(xcov)
+    assert_allclose(ycov, np.linalg.multi_dot([jac, xcov2, jac.T]))
+
+    with pytest.raises(ValueError):
+        propagate(fn, x, np.ones(2))
+
+    with pytest.raises(ValueError):
+        propagate(fn, x, np.ones((2, 2)))
+
+
+def test_10():
+    def fn(x):
+        return np.sum(x)
+
+    x = np.arange(2)
+    xcov = [[1, 0], [0, 1]]
+    y, ycov = propagate(fn, x, xcov)
+    assert_allclose(y, fn(x))
+    jac = np.ones((1, len(x)))
+    assert_allclose(ycov, np.linalg.multi_dot([jac, xcov, jac.T]))
+
+
+def test_11():
+    A = np.array([(1, 2), (3, 4), (5, 6)], dtype=float)
+
+    def fn(x):
+        return np.dot(A, x)
+
+    x = np.arange(2)
+    xcov = [[1, 0], [0, 1]]
+    y, ycov = propagate(fn, x, xcov)
+    assert_allclose(y, fn(x))
+    jac = A
+    assert_allclose(ycov, np.linalg.multi_dot([jac, xcov, jac.T]))

--- a/test/test_propagate.py
+++ b/test/test_propagate.py
@@ -6,7 +6,7 @@ import pytest
 
 def test_00():
     def fn(x):
-        return x ** 2 + 5
+        return x**2 + 5
 
     x = 2
     xcov = 3
@@ -17,7 +17,7 @@ def test_00():
 
 def test_01():
     def fn(x):
-        return np.ones(2) * x ** 2
+        return np.ones(2) * x**2
 
     x = 2
     xcov = 3


### PR DESCRIPTION
Adds function `propagate`, which uses the jacobian to perform error propagation for an arbitrary function that maps scalars or 1d arrays to scalars or 1d arrays.